### PR TITLE
Add Eslint CI action

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,11 @@
+name: CI
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install modules
+      run: yarn
+    - name: Run ESLint
+      run: eslint . --ext .ts

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,4 +11,4 @@ jobs:
         cache: 'npm'
     - run: npm i --include=dev
     - name: Run ESLint
-      run: npx eslint . --ext .ts
+      run: npm run lint

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,6 +9,6 @@ jobs:
       with:
         node-version: 18
         cache: 'npm'
-    - run: npm i
+    - run: npm i --include=dev
     - name: Run ESLint
-      run: eslint . --ext .ts
+      run: npx eslint . --ext .ts

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -4,8 +4,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Install modules
-      run: yarn
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 18
+        cache: 'npm'
+    - run: npm i
     - name: Run ESLint
       run: eslint . --ext .ts

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -8,7 +8,11 @@ jobs:
     - uses: actions/setup-node@v3
       with:
         node-version: 18
-        cache: 'npm'
-    - run: npm i --include=dev
-    - name: Run ESLint
-      run: npm run lint
+        cache: 'yarn'
+    - name: Install
+      uses: borales/actions-yarn@v4
+      with:
+        cmd: install
+    - name: Lint
+      uses: borales/actions-yarn@v4
+        cmd: run lint

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,4 +15,4 @@ jobs:
         cmd: install
     - name: Lint
       uses: borales/actions-yarn@v4
-        cmd: run lint
+        cmd: lint

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-prettier": "^4.2.1",
+    "eslint-plugin-typescript-sort-keys": "^2.3.0",
     "prettier": "^2.8.7",
     "typescript": "^5.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "bash scripts/dev_env.sh",
     "start": "ts-node src/index.ts",
-    "lint": "eslint --fix . --ext .ts",
+    "lint": "eslint . --ext .ts",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "bash scripts/dev_env.sh",
     "start": "ts-node src/index.ts",
     "lint": "eslint . --ext .ts",
-    "lint:fix": "npm run lint -- --fix",
+    "lint:fix": "yarn lint -- --fix",
+
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "bash scripts/dev_env.sh",
     "start": "ts-node src/index.ts",
     "lint": "eslint . --ext .ts",
+    "lint:fix": "npm run lint -- --fix",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ app.use(express.urlencoded({ extended: true }));
 
 app
   .use(session({ secret: 'grant', saveUninitialized: true, resave: false }))
+  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   .use(grant.express(Configuration.grant));
 
 app.get('/persistToken/:maskedUserId', (req, res) => {


### PR DESCRIPTION
Adds a small ESLint check to a Pipeline. I'm sure somewhere in your settings you can say that PRs are blocked unless this check passes.

Also ignores the one error that was being picked up because I couldn't actually find a way to fix it.

Explicitly adds a dependency that was mentioned in the ESLint configuration and removes `--fix` for consistency. Changes in the pipeline don't get applied to the PR.

Happy to work with you on adding or removing changes as desired.